### PR TITLE
Remove gap from CSP

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,15 +3,14 @@
 <head>
   <meta charset="utf-8">
   <!--
-  Customize this policy to fit your own app's needs. For more guidance, see:
-      https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
+  Customize this policy to fit your own app's needs. For more guidance, please refer to the docs:
+      https://cordova.apache.org/docs/en/latest/
   Some notes:
-    * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
     * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: content:">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, minimal-ui, viewport-fit=cover">
 
   <meta name="theme-color" content="#000000">

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
   <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: content:">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, minimal-ui, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
 
   <meta name="theme-color" content="#000000">
   <meta name="format-detection" content="telephone=no">


### PR DESCRIPTION
In the recent release of Cordova CLI 11.0.0 the newest App Hello World template 6.0.0 is used for all new projects, in which the `gap:` (which was needed when using UIWebView on iOS) from the Content Security Policy has been completely removed.

So I thought of making the same change in framework7-appstore-react index.html file.